### PR TITLE
When a dropdown is open, block Tab to avoid navigating away.

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -87,7 +87,7 @@ Hooks.Menu = {
       let menuItems = this.menuItems()
       this.deactivate(menuItems)
       this.activate(menuItems.indexOf(this.activeItem) - 1, menuItems.length - 1)
-    } else if (e.key == "Tab") {
+    } else if (e.key === "Tab"){
       e.preventDefault()
     }
   }


### PR DESCRIPTION
Under Windows, dropdowns cannot be tabbed off of. They are only closed by either selecting an item or pressing Escape.
