### PR TITLE
Improve accessibility of modal in general, and of upload form in particular

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -236,7 +236,6 @@ Hooks.Modal = {
   },
   destroyed() {
     this.beforeFocusEl.removeEventListener("focus", () => this.beforeFocus())
-    this.beforeFocusEl.style.display = "none"
     this.afterFocusEl.removeEventListener("focus", () => this.afterFocus())
     if (lastFocusedElement) {
       lastFocusedElement.focus()
@@ -244,7 +243,6 @@ Hooks.Modal = {
   },
   showBeforeFocus() {
     this.beforeFocusEl.addEventListener("focus", () => this.beforeFocus())
-    this.beforeFocusEl.style.display = "block"
   },
   beforeFocus() {
     this.focusLastDescendant(this.dialog)

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -238,6 +238,9 @@ Hooks.Modal = {
     this.beforeFocusEl.removeEventListener("focus", () => this.beforeFocus())
     this.beforeFocusEl.style.display = "none"
     this.afterFocusEl.removeEventListener("focus", () => this.afterFocus())
+    if (lastFocusedElement) {
+      lastFocusedElement.focus()
+    }
   },
   showBeforeFocus() {
     this.beforeFocusEl.addEventListener("focus", () => this.beforeFocus())
@@ -262,8 +265,8 @@ let lastFocusedElement = null
 let routeUpdated = () => {
   let target;
   if (lastFocusedElement != null) {
-    target = lastFocusedElement
     lastFocusedElement = null
+    return
   } else if (document.location.pathname.endsWith("/songs/new")) {
     target = document.querySelector("#layout")
     lastFocusedElement = document.activeElement

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -225,13 +225,13 @@ Hooks.Modal = {
     return false
   },
   mounted() {
-    this.dialog = this.el.querySelector(".dialog")
     this.beforeFocusEl = this.el.querySelector(".before-focus")
-    this.el.addEventListener("phx:show-end", () => this.showBeforeFocus())
+    this.beforeFocusEl.addEventListener("focus", () => this.beforeFocus())
     this.afterFocusEl = this.el.querySelector(".after-focus")
     this.afterFocusEl.addEventListener("focus", () => this.afterFocus())
+    this.el.addEventListener("phx:show-end", () => this.show())
     if (window.getComputedStyle(this.el).display !== "none") {
-      this.showBeforeFocus()
+      this.show()
     }
   },
   destroyed() {
@@ -241,14 +241,14 @@ Hooks.Modal = {
       lastFocusedElement.focus()
     }
   },
-  showBeforeFocus() {
-    this.beforeFocusEl.addEventListener("focus", () => this.beforeFocus())
+  show() {
+    this.el.focus()
   },
   beforeFocus() {
-    this.focusLastDescendant(this.dialog)
+    this.focusLastDescendant(this.el)
   },
   afterFocus() {
-    this.focusFirstDescendant(this.dialog)
+    this.focusFirstDescendant(this.el)
   }
 }
 
@@ -266,8 +266,8 @@ let routeUpdated = () => {
     lastFocusedElement = null
     return
   } else if (document.location.pathname.endsWith("/songs/new")) {
-    target = document.querySelector("#layout")
     lastFocusedElement = document.activeElement
+    return
   } else {
     target = document.querySelector("main h1") || document.querySelector("main")
   }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -174,9 +174,6 @@ Hooks.AudioPlayer = {
 Hooks.Modal = {
   // Subject to the W3C Software License at https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
   isFocusable(element) {
-    if (element == this.beforeFocusEl || element == this.afterFocusEl) {
-      return false
-    }
     if (element.tabIndex > 0 || (element.tabIndex === 0 && element.getAttribute("tabIndex") !== null)) {
       return true
     }
@@ -228,6 +225,7 @@ Hooks.Modal = {
     return false
   },
   mounted() {
+    this.dialog = this.el.querySelector("[role=dialog]")
     this.beforeFocusEl = this.el.querySelector(".before-focus")
     this.beforeFocusEl.addEventListener("focus", () => this.beforeFocus())
     this.afterFocusEl = this.el.querySelector(".after-focus")
@@ -245,13 +243,13 @@ Hooks.Modal = {
     }
   },
   show() {
-    this.el.focus()
+    this.dialog.focus()
   },
   beforeFocus() {
-    this.focusLastDescendant(this.el)
+    this.focusLastDescendant(this.dialog)
   },
   afterFocus() {
-    this.focusFirstDescendant(this.el)
+    this.focusFirstDescendant(this.dialog)
   }
 }
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -174,6 +174,9 @@ Hooks.AudioPlayer = {
 Hooks.Modal = {
   // Subject to the W3C Software License at https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
   isFocusable(element) {
+    if (element == this.beforeFocusEl || element == this.afterFocusEl) {
+      return false
+    }
     if (element.tabIndex > 0 || (element.tabIndex === 0 && element.getAttribute("tabIndex") !== null)) {
       return true
     }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -178,7 +178,12 @@ let liveSocket = new LiveSocket("/live", Socket, {
 })
 
 let routeUpdated = () => {
-  let target = document.querySelector("main h1") || document.querySelector("main")
+  let target;
+  if (document.location.pathname.endsWith("/songs/new")) {
+    target = document.querySelector("#layout")
+  } else {
+    target = document.querySelector("main h1") || document.querySelector("main")
+  }
   if (target) {
     let origTabIndex = target.getAttribute("tabindex")
     target.setAttribute("tabindex", "-1")
@@ -199,7 +204,7 @@ window.addEventListener("phx:page-loading-start", info => topbar.show())
 window.addEventListener("phx:page-loading-stop", info => topbar.hide())
 
 // Accessible routing
-window.addEventListener("phx:page-loading-stop", () => window.requestAnimationFrame(routeUpdated))
+window.addEventListener("phx:page-loading-stop", () => window.requestAnimationFrame(() => window.requestAnimationFrame(routeUpdated)))
 
 window.addEventListener("js:exec", e => e.target[e.detail.call](...e.detail.args))
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -177,10 +177,16 @@ let liveSocket = new LiveSocket("/live", Socket, {
   params: {_csrf_token: csrfToken}
 })
 
+let lastFocusedElement = null
+
 let routeUpdated = () => {
   let target;
-  if (document.location.pathname.endsWith("/songs/new")) {
+  if (lastFocusedElement != null) {
+    target = lastFocusedElement
+    lastFocusedElement = null
+  } else if (document.location.pathname.endsWith("/songs/new")) {
     target = document.querySelector("#layout")
+    lastFocusedElement = document.activeElement
   } else {
     target = document.querySelector("main h1") || document.querySelector("main")
   }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -236,8 +236,6 @@ Hooks.Modal = {
     }
   },
   destroyed() {
-    this.beforeFocusEl.removeEventListener("focus", () => this.beforeFocus())
-    this.afterFocusEl.removeEventListener("focus", () => this.afterFocus())
     if (lastFocusedElement) {
       lastFocusedElement.focus()
     }

--- a/lib/live_beats_web/live/layout_component.ex
+++ b/lib/live_beats_web/live/layout_component.ex
@@ -17,6 +17,7 @@ defmodule LiveBeatsWeb.LayoutComponent do
       case assigns[:show] do
         %{module: _module, confirm: {text, attrs}} = show ->
           show
+          |> Map.put_new(:title, assigns[:show][:title])
           |> Map.put_new(:patch, nil)
           |> Map.put_new(:navigate, nil)
           |> Map.merge(%{confirm_text: text, confirm_attrs: attrs})
@@ -32,7 +33,7 @@ defmodule LiveBeatsWeb.LayoutComponent do
     ~H"""
     <div class={unless @show, do: "hidden"}>
       <%= if @show do %>
-        <.modal show id={@id} navigate={@show.navigate} patch={@show.patch}>
+        <.modal show id={@id} title={@show.title} navigate={@show.navigate} patch={@show.patch}>
           <.live_component module={@show.module} {@show} />
           <:cancel>Cancel</:cancel>
           <:confirm {@show.confirm_attrs}><%= @show.confirm_text %></:confirm>

--- a/lib/live_beats_web/live/layout_component.ex
+++ b/lib/live_beats_web/live/layout_component.ex
@@ -33,7 +33,8 @@ defmodule LiveBeatsWeb.LayoutComponent do
     ~H"""
     <div class={unless @show, do: "hidden"}>
       <%= if @show do %>
-        <.modal show id={@id} title={@show.title} navigate={@show.navigate} patch={@show.patch}>
+        <.modal show id={@id} navigate={@show.navigate} patch={@show.patch}>
+          <:title><%= @show.title %></:title>
           <.live_component module={@show.module} {@show} />
           <:cancel>Cancel</:cancel>
           <:confirm {@show.confirm_attrs}><%= @show.confirm_text %></:confirm>

--- a/lib/live_beats_web/live/live_helpers.ex
+++ b/lib/live_beats_web/live/live_helpers.ex
@@ -382,7 +382,7 @@ defmodule LiveBeatsWeb.LiveHelpers do
             </div>
             <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left w-full mr-12">
               <h3 class="text-lg leading-6 font-medium text-gray-900" id={"#{@id}-title"}>
-                Title <%= render_slot(@title) %>
+                <%= render_slot(@title) %>
               </h3>
               <div class="mt-2">
                 <p id={"#{@id}-content"} class={"text-sm text-gray-500"}>

--- a/lib/live_beats_web/live/live_helpers.ex
+++ b/lib/live_beats_web/live/live_helpers.ex
@@ -360,7 +360,7 @@ defmodule LiveBeatsWeb.LiveHelpers do
 
     ~H"""
     <div id={@id} class={"fixed z-10 inset-0 overflow-y-auto #{if @show, do: "fade-in", else: "hidden"}"} aria-labelledby="modal-title" role="dialog" aria-modal="true" tabindex="0" phx-hook="Modal" {@rest}>
-      <span class="hidden before-focus" tabindex="0" aria-hidden="true" />
+      <span class="before-focus" tabindex="0" aria-hidden="true" />
       <div class="dialog flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
         <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
         <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>

--- a/lib/live_beats_web/live/live_helpers.ex
+++ b/lib/live_beats_web/live/live_helpers.ex
@@ -359,7 +359,7 @@ defmodule LiveBeatsWeb.LiveHelpers do
       |> assign_rest(~w(id show patch navigate on_cancel on_confirm title confirm cancel)a)
 
     ~H"""
-    <div id={@id} class={"fixed z-10 inset-0 overflow-y-auto #{if @show, do: "fade-in", else: "hidden"}"} aria-labelledby="modal-title" role="dialog" aria-modal="true" {@rest}>
+    <div id={@id} class={"fixed z-10 inset-0 overflow-y-auto #{if @show, do: "fade-in", else: "hidden"}"} aria-labelledby="modal-title" role="dialog" aria-modal="true" tabindex="0" {@rest}>
       <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
         <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
         <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>

--- a/lib/live_beats_web/live/live_helpers.ex
+++ b/lib/live_beats_web/live/live_helpers.ex
@@ -325,7 +325,6 @@ defmodule LiveBeatsWeb.LiveHelpers do
         {"ease-out duration-300", "opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95",
          "opacity-100 translate-y-0 sm:scale-100"}
     )
-    |> js_exec("##{id}-confirm", "focus", [])
   end
 
   def hide_modal(js \\ %JS{}, id) do
@@ -359,9 +358,9 @@ defmodule LiveBeatsWeb.LiveHelpers do
       |> assign_rest(~w(id show patch navigate on_cancel on_confirm title confirm cancel)a)
 
     ~H"""
-    <div id={@id} class={"fixed z-10 inset-0 overflow-y-auto #{if @show, do: "fade-in", else: "hidden"}"} aria-labelledby="modal-title" role="dialog" aria-modal="true" tabindex="0" phx-hook="Modal" {@rest}>
+    <div id={@id} class={"fixed z-10 inset-0 overflow-y-auto #{if @show, do: "fade-in", else: "hidden"}"} phx-hook="Modal" {@rest}>
       <span class="before-focus" tabindex="0" aria-hidden="true" />
-      <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+      <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0" aria-labelledby={"#{@id}-title"} role="dialog" aria-modal="true" tabindex="0" >
         <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
         <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
         <div
@@ -383,7 +382,7 @@ defmodule LiveBeatsWeb.LiveHelpers do
             </div>
             <div class="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left w-full mr-12">
               <h3 class="text-lg leading-6 font-medium text-gray-900" id={"#{@id}-title"}>
-                <%= render_slot(@title) %>
+                Title <%= render_slot(@title) %>
               </h3>
               <div class="mt-2">
                 <p id={"#{@id}-content"} class={"text-sm text-gray-500"}>

--- a/lib/live_beats_web/live/live_helpers.ex
+++ b/lib/live_beats_web/live/live_helpers.ex
@@ -359,8 +359,9 @@ defmodule LiveBeatsWeb.LiveHelpers do
       |> assign_rest(~w(id show patch navigate on_cancel on_confirm title confirm cancel)a)
 
     ~H"""
-    <div id={@id} class={"fixed z-10 inset-0 overflow-y-auto #{if @show, do: "fade-in", else: "hidden"}"} aria-labelledby="modal-title" role="dialog" aria-modal="true" tabindex="0" {@rest}>
-      <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+    <div id={@id} class={"fixed z-10 inset-0 overflow-y-auto #{if @show, do: "fade-in", else: "hidden"}"} aria-labelledby="modal-title" role="dialog" aria-modal="true" tabindex="0" phx-hook="Modal" {@rest}>
+      <span class="hidden before-focus" tabindex="0" aria-hidden="true" />
+      <div class="dialog flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
         <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
         <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
         <div
@@ -398,7 +399,6 @@ defmodule LiveBeatsWeb.LiveHelpers do
                 class="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-red-600 text-base font-medium text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 sm:ml-3 sm:w-auto sm:text-sm"
                 phx-click={@on_confirm}
                 phx-disable-with
-                tabindex="1"
                 {assigns_to_attributes(confirm)}
               >
                 <%= render_slot(confirm) %>
@@ -408,7 +408,6 @@ defmodule LiveBeatsWeb.LiveHelpers do
               <button
                 class="mt-3 w-full inline-flex justify-center rounded-md border border-gray-300 shadow-sm px-4 py-2 bg-white text-base font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:mt-0 sm:w-auto sm:text-sm"
                 phx-click={hide_modal(@on_cancel, @id)}
-                tabindex="2"
                 {assigns_to_attributes(cancel)}
               >
                 <%= render_slot(cancel) %>
@@ -417,6 +416,7 @@ defmodule LiveBeatsWeb.LiveHelpers do
           </div>
         </div>
       </div>
+      <span class="after-focus" tabindex="0" aria-hidden="true" />
     </div>
     """
   end

--- a/lib/live_beats_web/live/live_helpers.ex
+++ b/lib/live_beats_web/live/live_helpers.ex
@@ -361,7 +361,7 @@ defmodule LiveBeatsWeb.LiveHelpers do
     ~H"""
     <div id={@id} class={"fixed z-10 inset-0 overflow-y-auto #{if @show, do: "fade-in", else: "hidden"}"} aria-labelledby="modal-title" role="dialog" aria-modal="true" tabindex="0" phx-hook="Modal" {@rest}>
       <span class="before-focus" tabindex="0" aria-hidden="true" />
-      <div class="dialog flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
+      <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0">
         <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
         <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
         <div

--- a/lib/live_beats_web/live/live_helpers.ex
+++ b/lib/live_beats_web/live/live_helpers.ex
@@ -360,7 +360,7 @@ defmodule LiveBeatsWeb.LiveHelpers do
     ~H"""
     <div id={@id} class={"fixed z-10 inset-0 overflow-y-auto #{if @show, do: "fade-in", else: "hidden"}"} phx-hook="Modal" {@rest}>
       <span class="before-focus" tabindex="0" aria-hidden="true" />
-      <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0" aria-labelledby={"#{@id}-title"} role="dialog" aria-modal="true" tabindex="0" >
+      <div class="flex items-end justify-center min-h-screen pt-4 px-4 pb-20 text-center sm:block sm:p-0" aria-labelledby={"#{@id}-title"} aria-describedby={"#{@id}-description"} role="dialog" aria-modal="true" tabindex="0" >
         <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" aria-hidden="true"></div>
         <span class="hidden sm:inline-block sm:align-middle sm:h-screen" aria-hidden="true">&#8203;</span>
         <div

--- a/lib/live_beats_web/live/profile_live/song_entry_component.ex
+++ b/lib/live_beats_web/live/profile_live/song_entry_component.ex
@@ -22,7 +22,8 @@ defmodule LiveBeatsWeb.ProfileLive.SongEntryComponent do
           <% end %>
         </label>
         <input type="text" name={"songs[#{@ref}][title]"} value={@title}
-          class="block w-full border-0 p-0 text-gray-900 placeholder-gray-500 focus:ring-0 sm:text-sm"/>
+          class="block w-full border-0 p-0 text-gray-900 placeholder-gray-500 focus:ring-0 sm:text-sm"
+          autofocus/>
       </div>
       <div class="border border-gray-300 rounded-md px-3 py-2 mt-2 shadow-sm focus-within:ring-1 focus-within:ring-indigo-600 focus-within:border-indigo-600">
         <label for="name" class="block text-xs font-medium text-gray-900">Artist</label>

--- a/lib/live_beats_web/live/profile_live/song_entry_component.ex
+++ b/lib/live_beats_web/live/profile_live/song_entry_component.ex
@@ -46,7 +46,7 @@ defmodule LiveBeatsWeb.ProfileLive.SongEntryComponent do
       <div class="col-span-full sm:grid sm:grid-cols-2 sm:gap-2 sm:items-start">
         <.error input_name={"songs[#{@ref}][attribution]"} field={:attribution} errors={@errors} class="-mt-1"/>
       </div>
-      <div style={"width: #{@progress}%;"} class="col-span-full bg-purple-500 dark:bg-purple-400 h-1.5 w-0 p-0">
+      <div role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow={@progress} style={"width: #{@progress}%;"} class="col-span-full bg-purple-500 dark:bg-purple-400 h-1.5 w-0 p-0">
       </div>
     </div>
     """

--- a/lib/live_beats_web/live/profile_live/upload_form_component.html.heex
+++ b/lib/live_beats_web/live/profile_live/upload_form_component.html.heex
@@ -44,7 +44,7 @@
                   <path d="M28 8H12a4 4 0 00-4 4v20m32-12v8m0 0v8a4 4 0 01-4 4H12a4 4 0 01-4-4v-4m32-4l-3.172-3.172a4 4 0 00-5.656 0L28 28M8 32l9.172-9.172a4 4 0 015.656 0L28 28m0 0l4 4m4-24h8m-4-4v8m-12 4h.02" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"></path>
                 </svg>
                 <div class="flex text-sm text-gray-600">
-                  <label for="file-upload" class="relative cursor-pointer bg-white rounded-md font-medium text-indigo-600 hover:text-indigo-500 focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-indigo-500">
+                  <label for="file-upload" class="relative cursor-pointer bg-white rounded-md font-medium text-indigo-600 hover:text-indigo-500 focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-indigo-500" id="layout-description">
                     <span phx-click={JS.dispatch("click", to: "##{@uploads.mp3.ref}")}>Upload files</span>
                     <%= live_file_input @uploads.mp3, class: "sr-only", tabindex: "0" %>
                   </label>

--- a/lib/live_beats_web/live/profile_live/upload_form_component.html.heex
+++ b/lib/live_beats_web/live/profile_live/upload_form_component.html.heex
@@ -1,6 +1,4 @@
 <div>
-  <h2><%= @title %></h2>
-
   <.form
     for={:songs}
     id="song-form"

--- a/lib/live_beats_web/live/profile_live/upload_form_component.html.heex
+++ b/lib/live_beats_web/live/profile_live/upload_form_component.html.heex
@@ -48,7 +48,7 @@
                 <div class="flex text-sm text-gray-600">
                   <label for="file-upload" class="relative cursor-pointer bg-white rounded-md font-medium text-indigo-600 hover:text-indigo-500 focus-within:outline-none focus-within:ring-2 focus-within:ring-offset-2 focus-within:ring-indigo-500">
                     <span phx-click={JS.dispatch("click", to: "##{@uploads.mp3.ref}")}>Upload files</span>
-                    <%= live_file_input @uploads.mp3, class: "sr-only" %>
+                    <%= live_file_input @uploads.mp3, class: "sr-only", tabindex: "0" %>
                   </label>
                   <p class="pl-1">or drag and drop</p>
                 </div>


### PR DESCRIPTION
- Initial work on upload modal accessibility.
- Restore focus to last focused element when modal is closed.
- Adapt dialog focus solution from https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/dialog.html.
- Restore last focus immediately on destroying a dialog, and exit `routeUpdated` early to avoid redundant focus changes.
- Remove unnecessary style manipulation.
- Further simplifications:
- Consider focus traps non-focusable, avoiding deadlock when modal is empty.
- Set autofocus on title element to grab focus on upload completion.
- Make upload progress bar accessible.
