### PR TITLE
Simplify a few things

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -180,16 +180,10 @@ let liveSocket = new LiveSocket("/live", Socket, {
 let routeUpdated = () => {
   let target = document.querySelector("main h1") || document.querySelector("main")
   if (target) {
-    let origTabIndex = target.getAttribute("tabindex")
-    target.setAttribute("tabindex", "-1")
+    let origTabIndex = target.tabIndex
+    target.tabIndex = -1
     target.focus()
-    window.setTimeout(() => {
-      if (origTabIndex) {
-        target.setAttribute("tabindex", origTabIndex)
-      } else {
-        target.removeAttribute("tabindex")
-      }
-    }, 1000)
+    target.tabIndex = origTabIndex
   }
 }
 


### PR DESCRIPTION
Given that this is meant to be a sample, I wanted to make a quick simplification pass. There were a few instances where I inserted various timeouts in order to fix things, which were actually workarounds for elements not being visible and me not knowing it. I was a bit too trigger-happy in adding these delays, so I removed an unnecessary `requestAnimationFrame`.

I also simplified the routing focus. It no longer restores the original tabindex after a delay. Unfortunately I couldn't track down why that delay was necessary, but I went with a simpler implementation that leaves a few more `tabindex="1"`s in the rendered output. In doing this I hope to make the sample more approachable for anyone wanting to implement accessible routing in a Phoenix app.