### PR TITLE
Feature/fix styling

### DIFF
--- a/lib/live_beats_web/live/live_helpers.ex
+++ b/lib/live_beats_web/live/live_helpers.ex
@@ -451,15 +451,17 @@ defmodule LiveBeatsWeb.LiveHelpers do
 
     ~H"""
     <!-- Page title & actions -->
-    <div class="border-b border-gray-200 px-4 py-4 sm:flex sm:items-center sm:justify-between sm:px-6 lg:px-8 h-16">
+    <div class="border-b border-gray-200 px-4 py-4 sm:flex sm:items-center sm:justify-between sm:px-6 lg:px-8 sm:h-16">
       <div class="flex-1 min-w-0">
         <h1 class="text-lg font-medium leading-6 text-gray-900 sm:truncate focus:outline-none">
           <%= render_slot(@inner_block) %>
         </h1>
       </div>
-      <div class="mt-4 flex sm:mt-0 sm:ml-4">
-        <%= render_slot(@actions) %>
-      </div>
+      <%= if Enum.count(assigns.actions) > 0 do %>
+        <div class="mt-4 flex sm:mt-0 sm:ml-4 space-x-4">
+          <%= render_slot(@actions) %>
+        </div>
+      <% end %>
     </div>
     """
   end

--- a/lib/live_beats_web/live/live_helpers.ex
+++ b/lib/live_beats_web/live/live_helpers.ex
@@ -457,7 +457,7 @@ defmodule LiveBeatsWeb.LiveHelpers do
           <%= render_slot(@inner_block) %>
         </h1>
       </div>
-      <%= if Enum.count(assigns.actions) > 0 do %>
+      <%= if Enum.count(@actions) > 0 do %>
         <div class="mt-4 flex sm:mt-0 sm:ml-4 space-x-4">
           <%= render_slot(@actions) %>
         </div>

--- a/lib/live_beats_web/live/settings_live.ex
+++ b/lib/live_beats_web/live/settings_live.ex
@@ -9,7 +9,7 @@ defmodule LiveBeatsWeb.SettingsLive do
       Profile Settings
     </.title_bar>
 
-    <div class="max-w-3xl mx-auto mt-6">
+    <div class="max-w-3xl px-4 mx-auto mt-6">
       <.form let={f} for={@changeset} phx-change="validate" phx-submit="save" class="space-y-8 divide-y divide-gray-200">
         <div class="space-y-8 divide-y divide-gray-200">
           <div>


### PR DESCRIPTION
There are a few visual bugs in mobile view:
- Title bar had a fixed hight so the buttons would pop out of the bottom, also the title_bar would have bigger spacing since of the empty actions div with mt-4, so we do a check and not render it all if there are no actions
- Settings form expands to the edges on screens smaller than sm, added px-4 to fix this