### PR TITLE
Fix failed test due to page_title copy changes

### DIFF
--- a/test/live_beats_web/live/profile_live_test.exs
+++ b/test/live_beats_web/live/profile_live_test.exs
@@ -26,7 +26,7 @@ defmodule LiveBeatsWeb.ProfileLiveTest do
              |> element("#upload-btn")
              |> render_click()
 
-      assert render(lv) =~ "Add Songs"
+      assert render(lv) =~ "Add Music"
 
       mp3 =
         file_input(lv, "#song-form", :mp3, [


### PR DESCRIPTION
- This test was broken due to changes in [1: ef4097c]
  where the page_title changed from `Add Songs` to `Add Music`

1: 2022-02-02 ef4097c0a3005eb3edba9036beb6a77f167bdf9a
   Add more aggressive expiration and tell user about it