### PR TITLE
Fix target blank for profile live

### DIFF
--- a/lib/live_beats_web/live/profile_live.ex
+++ b/lib/live_beats_web/live/profile_live.ex
@@ -14,7 +14,7 @@ defmodule LiveBeatsWeb.ProfileLive do
         <div class="block">
           <%= @profile.tagline %> <%= if @owns_profile? do %>(you)<% end %>
         </div>
-        <.link href={@profile.external_homepage_url} _target="blank" class="block text-sm text-gray-600">
+        <.link href={@profile.external_homepage_url} target="_blank" class="block text-sm text-gray-600">
           <.icon name={:code}/> <span class=""><%= url_text(@profile.external_homepage_url) %></span>
         </.link>
       </div>


### PR DESCRIPTION
Target blank not rendered correctly because of this previous version of this code changes.
![Capture](https://user-images.githubusercontent.com/50759463/152359847-b3488c50-899a-4fa2-903b-f94ed8231b98.PNG)
