### PR TITLE
Remove block class from profile link

### DIFF
--- a/lib/live_beats_web/live/profile_live.ex
+++ b/lib/live_beats_web/live/profile_live.ex
@@ -14,7 +14,7 @@ defmodule LiveBeatsWeb.ProfileLive do
         <div class="block">
           <%= @profile.tagline %> <%= if @owns_profile? do %>(you)<% end %>
         </div>
-        <.link href={@profile.external_homepage_url} target="_blank" class="block text-sm text-gray-600">
+        <.link href={@profile.external_homepage_url} target="_blank" class="text-sm text-gray-600">
           <.icon name={:code}/> <span class=""><%= url_text(@profile.external_homepage_url) %></span>
         </.link>
       </div>


### PR DESCRIPTION
As a block the link extends the full width of the header and is too easy to click on accidentally.

| Before | After |
| ------ | ----- |
| <img width="236" alt="github_link_before" src="https://user-images.githubusercontent.com/168677/152382729-e27c50e4-d7f7-4727-8076-23d2c5b6a61f.png"> | <img width="245" alt="github_link_after" src="https://user-images.githubusercontent.com/168677/152382761-17fc3f75-a4f7-460b-803b-8dfe75793e09.png"> |
