### PR TITLE
Add now playing info

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -116,7 +116,7 @@ Hooks.AudioPlayer = {
         this.play()
       }
     })
-    this.handleEvent("play", ({url, token, elapsed}) => {
+    this.handleEvent("play", ({url, token, elapsed, artist, title}) => {
       this.playbackBeganAt = nowSeconds() - elapsed
       let currentSrc = this.player.src.split("?")[0]
       if(currentSrc === url && this.player.paused){
@@ -124,6 +124,10 @@ Hooks.AudioPlayer = {
       } else if(currentSrc !== url) {
         this.player.src = `${url}?token=${token}`
         this.play({sync: true})
+      }
+
+      if("mediaSession" in navigator){
+        navigator.mediaSession.metadata = new MediaMetadata({artist, title})
       }
     })
     this.handleEvent("pause", () => this.pause())

--- a/lib/live_beats_web/live/player_live.ex
+++ b/lib/live_beats_web/live/player_live.ex
@@ -314,6 +314,8 @@ defmodule LiveBeatsWeb.PlayerLive do
       })
 
     push_event(socket, "play", %{
+      artist: song.artist,
+      title: song.title,
       paused: Song.paused?(song),
       elapsed: elapsed,
       duration: song.duration,

--- a/lib/live_beats_web/live/player_live.ex
+++ b/lib/live_beats_web/live/player_live.ex
@@ -276,13 +276,17 @@ defmodule LiveBeatsWeb.PlayerLive do
   defp play_song(socket, %Song{} = song, elapsed) do
     socket
     |> push_play(song, elapsed)
-    |> assign(song: song, playing: true)
+    |> assign(song: song, playing: true, page_title: song_title(song))
   end
 
   defp stop_song(socket) do
     socket
     |> push_event("stop", %{})
-    |> assign(song: nil, playing: false)
+    |> assign(song: nil, playing: false, page_title: "Listing Songs")
+  end
+
+  defp song_title(%{artist: artist, title: title}) do
+    "#{title} - #{artist} (Now Playing)"
   end
 
   defp play_current_song(socket) do


### PR DESCRIPTION
Two changes related to showing "now playing" information:

1. On play, set the `:page_title` to "{title} - {artist} (Now Playing)"
2. Implement the [Media Session API](https://web.dev/media-session/#let-users-know-what's-playing) when available. Useful for mobile media players.

| Before | After |
| ------ | ----- |
| ![Before this PR](https://user-images.githubusercontent.com/168677/152400952-036297ce-e60e-4237-a1f6-2da69a356d03.png) | ![After adding Media Session API](https://user-images.githubusercontent.com/168677/152401005-1b296a70-0792-4677-958d-5764d067a92e.png) |

^^ Note the duration/scrubber are not directly part of the change - these screenshots were taken in two different states. This change is just about the metadata info.

