### PR TITLE
Support for MP3 files without ID3 headers

### DIFF
--- a/lib/live_beats/mp3_stat.ex
+++ b/lib/live_beats/mp3_stat.ex
@@ -85,6 +85,15 @@ defmodule LiveBeats.MP3Stat do
     parse_frames(major_version, rest, tag_size - ext_header_size, [])
   end
 
+  defp parse_tag(<<
+    _first::integer,
+    _second::integer,
+    _third::integer,
+    _rest::binary
+  >>) do
+      {%{}, binary} # has no ID3
+  end
+
   defp parse_tag(_), do: {%{}, ""}
 
   defp decode_synchsafe_integer(<<bin>>), do: bin


### PR DESCRIPTION
Added a pattern match to check for a minimum valid MP3 file without ID3 tags (e.g. converted from a WAV)