### PR TITLE
Add missing instruction in README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,5 @@ npm-debug.log
 /assets/node_modules/
 
 /priv/uploads
+/priv/static
 /tmp

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Visit [livebeats.fly.dev](http://livebeats.fly.dev) to try it out, or run locall
 
   * Install dependencies with `mix deps.get`
   * Create and migrate your database with `mix ecto.setup`
+  * Build assets with `mix assets.deploy`
   * Start Phoenix endpoint with `mix phx.server` or inside IEx with `iex -S mix phx.server`
 
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.


### PR DESCRIPTION
When I finished setting up the application I figured css classes were missing. I thought maybe we could add this instruction to get the app running properly in local environments.