### PR TITLE
pass through assign attrs in link#navigate helper

### DIFF
--- a/lib/live_beats_web/live/live_helpers.ex
+++ b/lib/live_beats_web/live/live_helpers.ex
@@ -124,9 +124,11 @@ defmodule LiveBeatsWeb.LiveHelpers do
 
   def link(%{navigate: _to} = assigns) do
     assigns = assign_new(assigns, :class, fn -> nil end)
+    opts = assigns_to_attributes(assigns, [:navigate])
+    assigns = assign(assigns, :opts, opts)
 
     ~H"""
-    <a href={@navigate} data-phx-link="redirect" data-phx-link-state="push" class={@class}>
+    <a href={@navigate} data-phx-link="redirect" data-phx-link-state="push" {@opts}>
       <%= render_slot(@inner_block) %>
     </a>
     """


### PR DESCRIPTION
I noticed that the keyboard navigation of the Sidebar User Menu wasn't working for anything except the Sign Out link.  The issue was the attributes that are passed in to the other menu items (i.e. `role="menuitem"`) were being dropped  in the live link helper:

```elixir
def link(%{navigate: _to} = assigns do
   # ...
end
```

Rather than passing along all incoming assigns as attributes, it was extracting just the `class` assign and using that.  This PR just updates that `link/1` function so it works like the other `link/1` helpers.

I'd also like to thank you for putting together a project like this.  Invaluable resource for learning the new features of LiveView.