### PR TITLE
Use `live_redirect/2` instead of internal data attributes

### DIFF
--- a/lib/live_beats_web/live/live_helpers.ex
+++ b/lib/live_beats_web/live/live_helpers.ex
@@ -126,9 +126,9 @@ defmodule LiveBeatsWeb.LiveHelpers do
     assigns = assign_new(assigns, :class, fn -> nil end)
 
     ~H"""
-    <a href={@navigate} data-phx-link="redirect" data-phx-link-state="push" class={@class}>
+    <%= live_redirect to: @navigate, class: @class do %>
       <%= render_slot(@inner_block) %>
-    </a>
+    <% end %>
     """
   end
 


### PR DESCRIPTION
The implementation of `LiveHelpers.link/1` for the `:navigate` case was using data attributes (`data-phx-link` and `data-phx-link-state`) that are internal to the implementation of LiveView's live navigation.

This change refactors `link/1` to use the public `LiveView.Helpers.live_redirect/2` to achieve the same behavior.