### PR TITLE
Update Song with correct MP3 metadata

### DIFF
--- a/lib/live_beats/media_library/song.ex
+++ b/lib/live_beats/media_library/song.ex
@@ -50,6 +50,8 @@ defmodule LiveBeats.MediaLibrary.Song do
     changeset
     |> put_duration(stat.duration)
     |> Ecto.Changeset.put_change(:mp3_filesize, stat.size)
+    |> Ecto.Changeset.put_change(:artist, stat.artist)
+    |> Ecto.Changeset.put_change(:title, stat.title)
   end
 
   defp put_duration(%Ecto.Changeset{} = changeset, duration) when is_integer(duration) do


### PR DESCRIPTION
This commit fixes an issue where the title/artist information of
uploaded files isn't accurate when uploading mp3s. The MP3Stat module
seems to parse the mp3 correctly, but doesn't update the `artist` and
`title` when updating the `duration`, so in some cases the information
saved in the database for a song (and displayed in the UI) will be
incorrect or poorly formatted.

Screenshots of the issue:
![Screen Shot 2022-07-27 at 6 29 42 PM](https://user-images.githubusercontent.com/1091204/181391023-833d4227-fff2-4da2-8aff-521dd74c1fe7.png)
![Screen Shot 2022-07-27 at 6 31 01 PM](https://user-images.githubusercontent.com/1091204/181391025-6cf7da28-d411-4e04-bfa9-4b50c4526f9d.png)

Screenshots after the fix locally:
![Screen Shot 2022-07-27 at 6 30 19 PM](https://user-images.githubusercontent.com/1091204/181391042-bb308388-6150-4d6b-9a77-f5905c58e744.png)
![Screen Shot 2022-07-27 at 6 30 49 PM](https://user-images.githubusercontent.com/1091204/181391044-f9922693-5abd-44e8-a330-8803460913b1.png)
